### PR TITLE
Fix test.sh by using the supplied command in docker-entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ COPY [ "/src/vsftpd.conf", "/etc" ]
 COPY [ "/src/docker-entrypoint.sh", "/" ]
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "/usr/sbin/vsftpd" ]
 EXPOSE 20/tcp 21/tcp 40000-40009/tcp
 HEALTHCHECK CMD netstat -lnt | grep :21 || exit 1

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -22,4 +22,4 @@ tail -f /var/log/vsftpd.log | tee /dev/stdout &
 touch /var/log/xferlog
 tail -f /var/log/xferlog | tee /dev/stdout &
 
-/usr/sbin/vsftpd
+exec "$@"


### PR DESCRIPTION
Docker uses a 2-part separation between the `ENTRYPOINT` command (which is what's always run in `docker run`) and the `CMD` command (which is provided _as arguments_ to the `ENTRYPOINT` script). Right now, `test.sh` doesn't work because it's attempting to override `CMD`, but `docker-entrypoint.sh` is _ignoring_ `CMD` in favor of a hardcoded call to `/usr/sbin/vsftpd`.

The fix for this is really easy, as you can see by the patch size! Specify what we were already doing as the `CMD` and have `docker-entrypoint.sh` call it. This means when you override `CMD` like `test.sh` does, `docker-entrypoint.sh` respects what you ask for.