### PR TITLE
Introduce CHOWN_FILES_ON_STARTUP env var, which defaults to 1 but can be disabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.19.0
 ENV FTP_USER=foo \
 	FTP_PASS=bar \
+	CHOWN_FILES_ON_STARTUP=1 \
 	GID=1000 \
 	UID=1000
 

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -14,7 +14,12 @@ adduser \
 	$FTP_USER
 
 mkdir -p /home/$FTP_USER
-chown -R $FTP_USER:$FTP_USER /home/$FTP_USER
+if [ -n "$CHOWN_FILES_ON_STARTUP" ]; then
+	echo "Fixing file ownership..."
+	chown -R $FTP_USER:$FTP_USER /home/$FTP_USER
+else
+	echo "Not changing file ownership."
+fi
 echo "$FTP_USER:$FTP_PASS" | /usr/sbin/chpasswd
 
 touch /var/log/vsftpd.log


### PR DESCRIPTION
I have a use case where it makes perfect sense to mount a read-only filesystem, as-is, and make no changes to ownership at the start of the container. I didn't want to change default behavior for everybody else, though! So I added an environment variable which allows for chowning to be an optional - but default - behavior. Anyone who needs to turn chowning off, they can.