### PR TITLE
feat(docker): adds PUBLIC_IP environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:3.20.3
 ENV FTP_USER=foo \
 	FTP_PASS=bar \
 	GID=1000 \
-	UID=1000
+	UID=1000 \
+	PUBLIC_IP=0.0.0.0
 
 RUN apk add --no-cache --update \
 	vsftpd==3.0.5-r2

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ docker run \
 	--detach \
 	--env FTP_PASS=123 \
 	--env FTP_USER=user \
+	--env PUBLIC_IP=192.168.0.1 \
 	--name my-ftp-server \
 	--publish 20-21:20-21/tcp \
 	--publish 40000-40009:40000-40009/tcp \
@@ -28,18 +29,37 @@ docker run \
 
 ```yml
 services:
-  ftp-server:
-    container_name: my-ftp-server
-    environment:
-      - FTP_PASS=123
-      - FTP_USER=user
-    image: garethflowers/ftp-server
-    ports:
-      - '20-21:20-21/tcp'
-      - '40000-40009:40000-40009/tcp' # Only needed for passive mode
-    volumes:
-      - '/data:/home/user'
+	ftp-server:
+		container_name: my-ftp-server
+		environment:
+			- PUBLIC_IP=192.168.0.1
+			- FTP_PASS=123
+			- FTP_USER=user
+		image: garethflowers/ftp-server
+		ports:
+			- "20-21:20-21/tcp"
+			- "40000-40009:40000-40009/tcp" # For passive mode
+		volumes:
+			- "/data:/home/user"
 ```
+
+## Configuration
+
+### Ports
+
+| Port           | Required? | Description                                                     | Config                                                                                                                                         |
+| -------------- | --------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 21             | Required  | The default port that FTP listens on.                           | [listen_port](https://security.appspot.com/vsftpd/vsftpd_conf.html)                                                                            |
+| 20             | Required  | The default port for PORT connections to originate.             | [ftp_data_port](https://security.appspot.com/vsftpd/vsftpd_conf.html)                                                                          |
+| 40000<br>40009 | Optional  | The min and max ports to use for PASV connections to originate. | [pasv_min_port](https://security.appspot.com/vsftpd/vsftpd_conf.html)<br>[pasv_max_port](https://security.appspot.com/vsftpd/vsftpd_conf.html) |
+
+### Environment Variables
+
+| Variable    | Default Value | Description                                       |
+| ----------- | ------------- | ------------------------------------------------- |
+| `FTP_PASS`  | `bar`         | The FTP password                                  |
+| `FTP_USER`  | `foo`         | The FTP username                                  |
+| `PUBLIC_IP` | `0.0.0.0`     | Public IP address to use for Passive connections. |
 
 ## License
 

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -17,6 +17,8 @@ mkdir -p /home/$FTP_USER
 chown -R $FTP_USER:$FTP_USER /home/$FTP_USER
 echo "$FTP_USER:$FTP_PASS" | /usr/sbin/chpasswd
 
+sed -i -r "s/0.0.0.0/$PUBLIC_IP/g" /etc/vsftpd.conf
+
 touch /var/log/vsftpd.log
 tail -f /var/log/vsftpd.log | tee /dev/stdout &
 touch /var/log/xferlog


### PR DESCRIPTION
Resolves #14.

Adds PUBLIC_IP environment variable that will be used by the `pasv_address` vsftpd.conf setting - instead of the default `0.0.0.0`.