### PR TITLE
fix(docker): call vsftpd directly if no additional args specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -20,4 +20,8 @@ tail -f /var/log/vsftpd.log | tee /dev/stdout &
 touch /var/log/xferlog
 tail -f /var/log/xferlog | tee /dev/stdout &
 
-exec "$@"
+if [ "$@" = "/usr/sbin/vsftpd" ]; then
+	/usr/sbin/vsftpd
+else
+	exec "$@"
+fi

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -20,7 +20,7 @@ tail -f /var/log/vsftpd.log | tee /dev/stdout &
 touch /var/log/xferlog
 tail -f /var/log/xferlog | tee /dev/stdout &
 
-if [ "$@" = "/usr/sbin/vsftpd" ]; then
+if [ "$*" = "/usr/sbin/vsftpd" ]; then
 	/usr/sbin/vsftpd
 else
 	exec "$@"


### PR DESCRIPTION
If no additional arguments are passed to `docker run` then call `/usr/sbin/vsftpd` directly in `docker-entrypoint.sh`.